### PR TITLE
Add validation for tag prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CONDITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.TagCommand;
@@ -63,9 +62,9 @@ public class TagCommandParser implements Parser<TagCommand> {
                 String prefix = part.split("/")[0] + "/";
 
                 // Skip if it's a valid prefix
-                if (prefix.equals(PREFIX_ALLERGY.toString()) ||
-                        prefix.equals(PREFIX_CONDITION.toString()) ||
-                        prefix.equals(PREFIX_INSURANCE.toString())) {
+                if (prefix.equals(PREFIX_ALLERGY.toString())
+                        || prefix.equals(PREFIX_CONDITION.toString())
+                        || prefix.equals(PREFIX_INSURANCE.toString())) {
                     continue;
                 }
 

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CONDITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.TagCommand;
@@ -17,10 +18,15 @@ import seedu.address.model.tag.Tag;
  */
 public class TagCommandParser implements Parser<TagCommand> {
 
+    public static final String MESSAGE_INVALID_TAG_PREFIX = "Invalid tag prefix. Only ta/, tc/, and ti/ are allowed.";
+
     @Override
     public TagCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ALLERGY,
                 PREFIX_CONDITION, PREFIX_INSURANCE);
+
+        // Check if any invalid prefixes are present in the command
+        checkForInvalidPrefixes(args);
 
         if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
@@ -39,5 +45,33 @@ public class TagCommandParser implements Parser<TagCommand> {
         Set<Tag> insurances = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_INSURANCE));
 
         return new TagCommand(index, allergies, conditions, insurances);
+    }
+
+    /**
+     * Checks if any invalid tag prefixes are present in the command.
+     * Only ta/, tc/, and ti/ are valid prefixes.
+     *
+     * @param args the command arguments
+     * @throws ParseException if an invalid prefix is detected
+     */
+    private void checkForInvalidPrefixes(String args) throws ParseException {
+        // Extract all prefixes from the command
+        String[] parts = args.trim().split("\\s+");
+
+        for (String part : parts) {
+            if (part.contains("/")) {
+                String prefix = part.split("/")[0] + "/";
+
+                // Skip if it's a valid prefix
+                if (prefix.equals(PREFIX_ALLERGY.toString()) ||
+                        prefix.equals(PREFIX_CONDITION.toString()) ||
+                        prefix.equals(PREFIX_INSURANCE.toString())) {
+                    continue;
+                }
+
+                // If we get here, we found an invalid prefix
+                throw new ParseException(MESSAGE_INVALID_TAG_PREFIX);
+            }
+        }
     }
 }


### PR DESCRIPTION
- Add validation to ensure only ta/, tc/, and ti/ prefixes are valid in tag commands
- Add error message constant for invalid tag prefixes
- Implement prefix validation method to check all command arguments
- Rejects commands like "tag 2 tn/paul" with appropriate error message